### PR TITLE
Update package references and version numbers

### DIFF
--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
@@ -12,14 +12,20 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-		<PackageReference Include="coverlet.collector" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-		<PackageReference Include="xunit" Version="2.5.3" />
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="Xunit.Di" Version="2.4.5" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
@@ -9,8 +9,8 @@
     <RepositoryUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>common service locator</PackageTags>
-    <AssemblyVersion>0.5.0</AssemblyVersion>
-    <Version>0.5.0</Version>
+    <AssemblyVersion>0.6.0</AssemblyVersion>
+    <Version>0.6.0</Version>
     <Title>CommonService Locator for MS.Dependency Injection</Title>
     <PackageProjectUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</PackageProjectUrl>
     <Copyright>2024</Copyright>
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated `vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj`:
- Removed old package references.
- Added new package references with updated versions:
  - `coverlet.collector` (6.0.2)
  - `Microsoft.Extensions.DependencyInjection` (9.0.0)
  - `Microsoft.Extensions.Hosting` (9.0.0)
  - `Microsoft.Extensions.Hosting.Abstractions` (9.0.0)
  - `Microsoft.NET.Test.Sdk` (17.11.1)
  - `xunit` (2.9.2)
- Added `PrivateAssets` and `IncludeAssets` attributes to `coverlet.collector` and `xunit.runner.visualstudio`.
- Updated `xunit.runner.visualstudio` to version 2.8.2.

Updated `vb2ae.ServiceLocator.MSDependencyInjection.csproj`:
- Changed `AssemblyVersion` and `Version` from 0.5.0 to 0.6.0.
- Updated `Microsoft.Extensions.DependencyInjection` from version 8.0.0 to 9.0.0.