### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -34,5 +34,5 @@ jobs:
       run: dotnet pack ${{env.servicelocator_sln}} --output ${{env.nuget_folder}}
       
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push packages/vb2ae.ServiceLocator.MSDependencyInjection.0.5.0.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
+      run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/dotnet.yml` file. The change updates the command to publish NuGet packages to GitHub, allowing it to handle multiple packages instead of a specific one.

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L37-R37): Modified the `dotnet nuget push` command to use a wildcard (`*.nupkg`) for publishing all packages in the directory instead of a single specified package.