### PR TITLE
have tests run on .net 9

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 


### PR DESCRIPTION
This pull request includes updates to the .NET version used in the project. The most important changes include updating the .NET version in the GitHub Actions workflow and the project file for the tests.

.NET version updates:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L26-R26): Updated the `dotnet-version` from `8.0.x` to `9.0.x` in the `Setup .NET` step.
* [`vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj`](diffhunk://#diff-a76f10845c469b50064c27830d98c146b5f96528abcd0110fdbc5e42753855a7L4-R4): Changed the `TargetFramework` from `net8.0` to `net9.0`.

closes #23 