### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           dotnet-version: 9.0.x
       - name: Restore dependencies
-        run: dotnet restore ${{servicelocator_sln}}
+        run: dotnet restore ${{env.servicelocator_sln}}
       - name: Build
-        run: dotnet build  ${{servicelocator_sln}} --no-restore --configuration Release 
+        run: dotnet build  ${{env.servicelocator_sln}} --no-restore --configuration Release 
       - name: Pack Nuget
         run: dotnet pack ${{env.servicelocator_sln}} --output ${{env.nuget_folder}}
       


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy.yml` file to fix environment variable references in the deployment workflow.

* Updated the `dotnet restore` command to use the correct environment variable `${{env.servicelocator_sln}}` instead of `${{servicelocator_sln}}`.
* Updated the `dotnet build` command to use the correct environment variable `${{env.servicelocator_sln}}` instead of `${{servicelocator_sln}}`.