### PR TITLE
add upload artifacts

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -50,3 +50,9 @@ jobs:
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_NUGET_PACKAGE}} --skip-duplicate
       if: github.event_name != 'pull_request'
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: published_nuget
+        path: packages/*.nupkg


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/dotnet.yml` file to enhance the workflow for publishing NuGet packages. The most important change is the addition of a step to upload the published NuGet packages as artifacts.

Enhancements to the workflow:

* Added a new step to upload the published NuGet packages as artifacts using the `actions/upload-artifact@v4` action. This step includes the artifact name `published_nuget` and specifies the path to the NuGet packages (`packages/*.nupkg`).