### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,4 +45,4 @@ jobs:
   
       
       - name: publish Nuget Packages to GitHub
-        run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate
+        run: dotnet nuget push *.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change simplifies the path for pushing NuGet packages by removing the `packages/` directory prefix.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L48-R48): Simplified the `run` command for publishing NuGet packages by removing the `packages/` directory prefix.