### PR TITLE
Fix bug and add sbom

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,6 +26,10 @@ jobs:
         dotnet-version: 9.0.x
     - name: Restore dependencies
       run: dotnet restore
+
+    - name: Install Microsoft SBom tool
+      run: dotnet tool install --global Microsoft.Sbom.DotNetTool
+
     - name: Build
       run: dotnet build --no-restore --configuration Release 
     - name: Test

--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/Models/IAmNotUsed.cs
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/Models/IAmNotUsed.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace vb2ae.ServiceLocator.MSDependencyInjection.Tests.Models
+{
+    internal interface IAmNotUsed
+    {
+    }
+}

--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/ServiceLocatorTests.cs
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/ServiceLocatorTests.cs
@@ -62,6 +62,14 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection.Tests
         }
 
         [Fact]
+        public void GetInstance_Type_WithNullKey()
+        {
+            var serviceType = typeof(IPet);
+
+            Assert.True(CommonServiceLocator.ServiceLocator.Current.GetInstance(serviceType, null) is IPet);
+        }
+
+        [Fact]
         public void GetInstance_Generic_ReturnsInstance()
         {
             var result = CommonServiceLocator.ServiceLocator.Current.GetInstance<IService>();
@@ -75,6 +83,13 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection.Tests
             var key = "Dog";
 
             Assert.True(CommonServiceLocator.ServiceLocator.Current.GetInstance<IPet>(key) is Dog);
+        }
+
+        [Fact]
+        public void GetInstance_Generic_WithNullKey()
+        {
+            var result = CommonServiceLocator.ServiceLocator.Current.GetInstance<IPet>(null);
+            Assert.True(result is IPet);
         }
 
         [Fact]

--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/ServiceLocatorTests.cs
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/ServiceLocatorTests.cs
@@ -93,6 +93,12 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection.Tests
         }
 
         [Fact]
+        public void GetInstance_Generic_WithNullKey_NotRegisterClass()
+        {
+            var result = CommonServiceLocator.ServiceLocator.Current.GetInstance<IAmNotUsed>(null);
+            Assert.True(result is null);
+        }
+        [Fact]
         public void GetService_Generic_ReturnsService()
         {
             var result = CommonServiceLocator.ServiceLocator.Current.GetService<IService>();

--- a/vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs
@@ -57,9 +57,9 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection
             if (string.IsNullOrEmpty(key))
             {
                 var services = GetAllInstances(serviceType);
-                if (services != null && services.Any())
+                if (services != null)
                 {
-                    return services.First();
+                    return services.FirstOrDefault();
                 }
                 return null;
             }
@@ -76,9 +76,9 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection
             if (string.IsNullOrEmpty(key))
             {
                 var services = GetAllInstances<TService>();
-                if (services != null && services.Any())
+                if (services != null)
                 {
-                    return services.First();
+                    return services.FirstOrDefault();
                 }
                 return default(TService);
             }

--- a/vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace vb2ae.ServiceLocator.MSDependencyInjection
 {
@@ -53,8 +54,15 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection
 
         public object GetInstance(Type serviceType, string key)
         {
-            // Microsoft.Extensions.DependencyInjection does not support keyed services out of the box.
-            // You might need to implement a custom logic or use a third-party library for this.
+            if (string.IsNullOrEmpty(key))
+            {
+                var services = GetAllInstances(serviceType);
+                if (services != null && services.Any())
+                {
+                    return services.First();
+                }
+                return null;
+            }
             return _serviceProvider.GetRequiredKeyedService(serviceType, key);
         }
 
@@ -65,6 +73,15 @@ namespace vb2ae.ServiceLocator.MSDependencyInjection
 
         public TService GetInstance<TService>(string key)
         {
+            if (string.IsNullOrEmpty(key))
+            {
+                var services = GetAllInstances<TService>();
+                if (services != null && services.Any())
+                {
+                    return services.First();
+                }
+                return default(TService);
+            }
             return _serviceProvider.GetKeyedService<TService>(key);
         }
 

--- a/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
@@ -1,37 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-    <AnalysisLevel>latest-all</AnalysisLevel>
-    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <RepositoryUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>common service locator</PackageTags>
-    <AssemblyVersion>0.9.0</AssemblyVersion>
-    <Version>0.9.0</Version>
-    <Title>CommonService Locator for MS.Dependency Injection</Title>
-    <PackageProjectUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</PackageProjectUrl>
-    <Copyright>2024</Copyright>
-    <Description>The purpose of this class library is to be able to use Microsoft.Extensions.DependencyInjection with the common service locator.</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Authors>Ken Tucker</Authors>
-    <RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
-    <SignAssembly>True</SignAssembly>
-    <AssemblyOriginatorKeyFile>servicelocator.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+		<AnalysisLevel>latest-all</AnalysisLevel>
+		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>common service locator</PackageTags>
+		<AssemblyVersion>0.9.0</AssemblyVersion>
+		<Version>0.9.0</Version>
+		<Title>CommonService Locator for MS.Dependency Injection</Title>
+		<PackageProjectUrl>https://github.com/vb2ae/vb2ae.ServiceLocator.MSDependencyInjection</PackageProjectUrl>
+		<Copyright>2024</Copyright>
+		<Description>The purpose of this class library is to be able to use Microsoft.Extensions.DependencyInjection with the common service locator.</Description>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<Authors>Ken Tucker</Authors>
+		<RunAnalyzersDuringBuild>True</RunAnalyzersDuringBuild>
+		<SignAssembly>True</SignAssembly>
+		<AssemblyOriginatorKeyFile>servicelocator.snk</AssemblyOriginatorKeyFile>
+		<GenerateSBOM>true</GenerateSBOM>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\README.md">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\README.md">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Sbom.Targets" Version="3.0.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request includes several changes to the `vb2ae.ServiceLocator.MSDependencyInjection` project, focusing on adding support for null keys, incorporating the Microsoft SBom tool, and updating dependencies. The most important changes are summarized below:

### Support for null keys:

* [`vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs`](diffhunk://#diff-30b734639495f1628b487dc73176dec5f3f883b0e7d198cd456c75dcdde1d18eL56-R65): Modified `GetInstance` methods to handle null keys by returning the first available instance of the requested service type. [[1]](diffhunk://#diff-30b734639495f1628b487dc73176dec5f3f883b0e7d198cd456c75dcdde1d18eL56-R65) [[2]](diffhunk://#diff-30b734639495f1628b487dc73176dec5f3f883b0e7d198cd456c75dcdde1d18eR76-R84)
* [`vb2ae.ServiceLocator.MSDependencyInjection.Tests/ServiceLocatorTests.cs`](diffhunk://#diff-70a370c63cb5cc200210343d8b6ac2b4f88095d2d7bfa09257bf2bc708549c6fR64-R71): Added new test cases to verify the behavior of `GetInstance` methods when the key is null. [[1]](diffhunk://#diff-70a370c63cb5cc200210343d8b6ac2b4f88095d2d7bfa09257bf2bc708549c6fR64-R71) [[2]](diffhunk://#diff-70a370c63cb5cc200210343d8b6ac2b4f88095d2d7bfa09257bf2bc708549c6fR88-R100)

### Incorporation of Microsoft SBom tool:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344R29-R32): Added a step to install the Microsoft SBom tool in the GitHub Actions workflow.
* [`vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj`](diffhunk://#diff-88c9305de0d5ab7cb29937457f42f9eb0336e6d22f37151093c2e0b1fc630f2aR23): Enabled SBOM generation by adding the `GenerateSBOM` property and included the `Microsoft.Sbom.Targets` package. [[1]](diffhunk://#diff-88c9305de0d5ab7cb29937457f42f9eb0336e6d22f37151093c2e0b1fc630f2aR23) [[2]](diffhunk://#diff-88c9305de0d5ab7cb29937457f42f9eb0336e6d22f37151093c2e0b1fc630f2aR36-R39)

### Codebase updates:

* [`vb2ae.ServiceLocator.MSDependencyInjection/MSDependencyInjectionServiceLocator.cs`](diffhunk://#diff-30b734639495f1628b487dc73176dec5f3f883b0e7d198cd456c75dcdde1d18eR5): Added missing `using System.Linq;` directive.
* [`vb2ae.ServiceLocator.MSDependencyInjection.Tests/Models/IAmNotUsed.cs`](diffhunk://#diff-cec3d802c3034b52baa718fee0d491f3ff2589900d868ea0bbcf172cd0444097R1-R12): Added a new internal interface `IAmNotUsed` for testing purposes.
Closes #30 