### PR TITLE
Update CI workflows for repository checkout and versioning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-
+      with:
+        fetch-depth: 0
+        
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,6 +31,11 @@ jobs:
 
     - name: Install Microsoft SBom tool
       run: dotnet tool install --global Microsoft.Sbom.DotNetTool
+      
+    - name: Install Nerdbank Git versioning
+      run: dotnet tool install -g nbgv    
+    - name: Set Version
+      run: nbgv cloud
 
     - name: Build
       run: dotnet build --no-restore --configuration Release 


### PR DESCRIPTION
Updated `codeql.yml` to use `actions/checkout@v4` with `fetch-depth: 0` to fetch the entire repository history. Added steps in `dotnet.yml` to install `nbgv` tool and set version using `nbgv cloud`.