### PR TITLE
Update vb2ae.ServiceLocator.MSDependencyInjection to use latest version of Microsoft.sbom.targets

### DIFF
--- a/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
@@ -33,7 +33,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.7" />
-		<PackageReference Include="Microsoft.Sbom.Targets" Version="4.0.3">
+		<PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.0">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
This pull request updates a dependency version in the project file to ensure compatibility and access to the latest features and fixes.

Dependency updates:

* Upgraded the `Microsoft.Sbom.Targets` package from version 4.0.3 to 4.1.0 in `vb2ae.ServiceLocator.MSDependencyInjection.csproj`.