### PR TITLE
Update Microsoft.Extensions.Hosting packages to 9.0.8

### DIFF
--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
@@ -30,8 +30,8 @@
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.7" />		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />		<PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />		<PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
 		<PackageReference Include="xunit.v3" Version="3.0.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
 


### PR DESCRIPTION
This pull request updates dependency versions in the test project to ensure compatibility and access to the latest features and fixes.

Dependency updates:

* Upgraded `Microsoft.Extensions.Hosting` and `Microsoft.Extensions.Hosting.Abstractions` package references from version 9.0.7 to 9.0.8 in `vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj`.