### PR TITLE
Update Microsoft.Extensions packages to version 10.0.5

### DIFF
--- a/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.Tests/vb2ae.ServiceLocator.MSDependencyInjection.Tests.csproj
@@ -28,9 +28,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 		  <PrivateAssets>all</PrivateAssets>

--- a/vb2ae.ServiceLocator.MSDependencyInjection.xunit/vb2ae.ServiceLocator.MSDependencyInjection.xunit.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection.xunit/vb2ae.ServiceLocator.MSDependencyInjection.xunit.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit.v3" Version="2.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />

--- a/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
+++ b/vb2ae.ServiceLocator.MSDependencyInjection/vb2ae.ServiceLocator.MSDependencyInjection.csproj
@@ -32,7 +32,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
 		<PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-  	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
 	  <PackageReference Update="Nerdbank.GitVersioning" Version="3.9.50" />
 	</ItemGroup>
 


### PR DESCRIPTION
This pull request updates the `Microsoft.Extensions.DependencyInjection` and related package dependencies to the latest patch version (10.0.5) across all relevant projects. This ensures consistency and pulls in the latest bug fixes and improvements from the upstream libraries.

Dependency updates:

* Updated `Microsoft.Extensions.DependencyInjection` from version 10.0.3 to 10.0.5 in `vb2ae.ServiceLocator.MSDependencyInjection`, `vb2ae.ServiceLocator.MSDependencyInjection.Tests`, and `vb2ae.ServiceLocator.MSDependencyInjection.xunit` project files. [[1]](diffhunk://#diff-88c9305de0d5ab7cb29937457f42f9eb0336e6d22f37151093c2e0b1fc630f2aL35-R43) [[2]](diffhunk://#diff-a76f10845c469b50064c27830d98c146b5f96528abcd0110fdbc5e42753855a7L31-R33) [[3]](diffhunk://#diff-42b2367818e25ad94c240a8f6cada0fdc687a5468bc6897879d45f7b4713d2e0L31-R31)
* Updated `Microsoft.Extensions.DependencyInjection.Abstractions` from version 10.0.3 to 10.0.5 in `vb2ae.ServiceLocator.MSDependencyInjection` and `vb2ae.ServiceLocator.MSDependencyInjection.Tests` project files. [[1]](diffhunk://#diff-88c9305de0d5ab7cb29937457f42f9eb0336e6d22f37151093c2e0b1fc630f2aL35-R43) [[2]](diffhunk://#diff-a76f10845c469b50064c27830d98c146b5f96528abcd0110fdbc5e42753855a7L31-R33)
* Updated `Microsoft.Extensions.Hosting` from version 10.0.3 to 10.0.5 in `vb2ae.ServiceLocator.MSDependencyInjection.Tests` project file.